### PR TITLE
Add back Agora AUSD to token list

### DIFF
--- a/tokens.json
+++ b/tokens.json
@@ -295,6 +295,17 @@
         "Stablecoins"
       ],
       "logoURI": "https://raw.githubusercontent.com/merchant-moe/moe-tokenlists/main/logos/0xfc421aD3C883Bf9E7C4f42dE845C4e4405799e73/logo.png"
+    },
+    {
+      "chainId": 5000,
+      "address": "0x00000000eFE302BEAA2b3e6e1b18d08D69a9012a",
+      "decimals": 6,
+      "name": "AUSD",
+      "symbol": "AUSD",
+      "tags": [
+        "Stablecoins"
+      ],
+      "logoURI": "https://raw.githubusercontent.com/merchant-moe/moe-tokenlists/main/logos/0x00000000eFE302BEAA2b3e6e1b18d08D69a9012a/logo.png"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Agora AUSD (`0x00000000eFE302BEAA2b3e6e1b18d08D69a9012a`) was accidentally removed alongside Aurelius aUSD in the inactive tokens cleanup (#59)
- This PR adds Agora AUSD back while keeping Aurelius aUSD removed